### PR TITLE
보고서 리스트 counter error 고침 - fix #96

### DIFF
--- a/photos/templates/main.html
+++ b/photos/templates/main.html
@@ -55,7 +55,7 @@
             <tr class="unread">
                 <td class="inbox-small-cells">
                     <!-- {{ post.pk }} -->
-                    {{ forloop.counter }}
+                    {{ forloop.revcounter }}
                 </td>
                 <td class="view-message  dont-show">
                     <a href="{{ post.get_absolute_url }}">
@@ -70,14 +70,6 @@
         {% endfor %}
         </tbody>
         </table>
-    </div>
-
-    {% if posts.has_next %}
-        <a class="infinite-more-link" href="?page={{ posts.next_page_number }}">More</a>
-    {% endif %}
-
-    <div class="loading" style="display: none;">
-        Loading...
     </div>
 </div>
 

--- a/photos/views.py
+++ b/photos/views.py
@@ -980,17 +980,7 @@ def main(request):
 
     dataList = Data.objects.filter(author__profile__group=groupobj, year=cur_year, sem=cur_sem).order_by('-id')
 
-    paginator = Paginator(dataList, 10)
-    page = request.GET.get('page', 1)
-
-    try:
-        posts = paginator.page(page)
-    except PageNotAnInteger:
-        posts = paginator.page(1)
-    except EmptyPage:
-        posts = paginator.page(paginator.num_pages)
-
-    ctx['posts'] = posts
+    ctx['posts'] = dataList
     ctx['userobj'] = user
 
     return render(request, 'main.html', ctx)


### PR DESCRIPTION
paginator로 인해 counter가 1부터 다시 시작하는 것이였다. 보고서의 개수가
15개 보다 많이 생성되지 않으므로 paginator를 없애주었다.

그리고 제일 오래된 것의 id가 1로 되게 변경하였다.